### PR TITLE
Add audio playback with visual feedback

### DIFF
--- a/transposition-frontend/src/components/play-button/index.tsx
+++ b/transposition-frontend/src/components/play-button/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { playNote, playScale, stopPlayback } from '../../utils/audioPlayer';
 
 type PlayButtonProps = {
@@ -13,6 +13,7 @@ type PlayButtonProps = {
 
 function PlayButton({ noteIndices, colour = 'sky', startOctave = 4, onNotePlay }: PlayButtonProps) {
   const [playing, setPlaying] = useState(false);
+  const noteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const colourClasses: Record<string, string> = {
     sky: 'text-sky-500 hover:text-sky-700',
@@ -23,6 +24,10 @@ function PlayButton({ noteIndices, colour = 'sky', startOctave = 4, onNotePlay }
 
   const handleClick = useCallback(async () => {
     if (playing) {
+      if (noteTimeoutRef.current) {
+        clearTimeout(noteTimeoutRef.current);
+        noteTimeoutRef.current = null;
+      }
       stopPlayback();
       setPlaying(false);
       onNotePlay?.(null);
@@ -33,7 +38,8 @@ function PlayButton({ noteIndices, colour = 'sky', startOctave = 4, onNotePlay }
     if (noteIndices.length === 1) {
       onNotePlay?.(0);
       playNote(noteIndices[0], 500, startOctave);
-      setTimeout(() => {
+      noteTimeoutRef.current = setTimeout(() => {
+        noteTimeoutRef.current = null;
         setPlaying(false);
         onNotePlay?.(null);
       }, 500);

--- a/transposition-frontend/src/components/play-button/index.tsx
+++ b/transposition-frontend/src/components/play-button/index.tsx
@@ -1,0 +1,61 @@
+import { useState, useCallback, useEffect } from 'react';
+import { playNote, playScale, stopPlayback } from '../../utils/audioPlayer';
+
+type PlayButtonProps = {
+  /** Chromatic note indices (0=C, 1=C#, ..., 11=B). Single note or scale. */
+  noteIndices: number[];
+  colour?: 'sky' | 'red' | 'amber' | 'purple';
+};
+
+function PlayButton({ noteIndices, colour = 'sky' }: PlayButtonProps) {
+  const [playing, setPlaying] = useState(false);
+
+  const colourClasses: Record<string, string> = {
+    sky: 'text-sky-500 hover:text-sky-600 hover:bg-sky-50',
+    red: 'text-red-400 hover:text-red-500 hover:bg-red-50',
+    amber: 'text-amber-500 hover:text-amber-600 hover:bg-amber-50',
+    purple: 'text-purple-500 hover:text-purple-600 hover:bg-purple-50',
+  };
+
+  const handleClick = useCallback(async () => {
+    if (playing) {
+      stopPlayback();
+      setPlaying(false);
+      return;
+    }
+
+    setPlaying(true);
+    if (noteIndices.length === 1) {
+      playNote(noteIndices[0]);
+      setTimeout(() => setPlaying(false), 500);
+    } else {
+      await playScale(noteIndices);
+      setPlaying(false);
+    }
+  }, [playing, noteIndices]);
+
+  useEffect(() => {
+    return () => stopPlayback();
+  }, []);
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors ${colourClasses[colour]} focus:outline-none focus:ring-2 focus:ring-offset-1`}
+      aria-label={playing ? 'Stop playback' : 'Play'}
+      title={playing ? 'Stop' : 'Play'}
+    >
+      {playing ? (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <rect x="3" y="3" width="10" height="10" rx="1" />
+        </svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M4 2.5v11l9-5.5z" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+export default PlayButton;

--- a/transposition-frontend/src/components/play-button/index.tsx
+++ b/transposition-frontend/src/components/play-button/index.tsx
@@ -11,10 +11,10 @@ function PlayButton({ noteIndices, colour = 'sky' }: PlayButtonProps) {
   const [playing, setPlaying] = useState(false);
 
   const colourClasses: Record<string, string> = {
-    sky: 'text-sky-500 hover:text-sky-600 hover:bg-sky-50',
-    red: 'text-red-400 hover:text-red-500 hover:bg-red-50',
-    amber: 'text-amber-500 hover:text-amber-600 hover:bg-amber-50',
-    purple: 'text-purple-500 hover:text-purple-600 hover:bg-purple-50',
+    sky: 'text-sky-500 hover:text-sky-700',
+    red: 'text-red-400 hover:text-red-600',
+    amber: 'text-amber-500 hover:text-amber-700',
+    purple: 'text-purple-500 hover:text-purple-700',
   };
 
   const handleClick = useCallback(async () => {

--- a/transposition-frontend/src/components/play-button/index.tsx
+++ b/transposition-frontend/src/components/play-button/index.tsx
@@ -7,9 +7,11 @@ type PlayButtonProps = {
   colour?: 'sky' | 'red' | 'amber' | 'purple';
   /** Starting octave for playback (default 4 = middle C octave). */
   startOctave?: number;
+  /** Called with the index of each note as it plays (scales only). */
+  onNotePlay?: (index: number | null) => void;
 };
 
-function PlayButton({ noteIndices, colour = 'sky', startOctave = 4 }: PlayButtonProps) {
+function PlayButton({ noteIndices, colour = 'sky', startOctave = 4, onNotePlay }: PlayButtonProps) {
   const [playing, setPlaying] = useState(false);
 
   const colourClasses: Record<string, string> = {
@@ -23,16 +25,22 @@ function PlayButton({ noteIndices, colour = 'sky', startOctave = 4 }: PlayButton
     if (playing) {
       stopPlayback();
       setPlaying(false);
+      onNotePlay?.(null);
       return;
     }
 
     setPlaying(true);
     if (noteIndices.length === 1) {
+      onNotePlay?.(0);
       playNote(noteIndices[0], 500, startOctave);
-      setTimeout(() => setPlaying(false), 500);
+      setTimeout(() => {
+        setPlaying(false);
+        onNotePlay?.(null);
+      }, 500);
     } else {
-      await playScale(noteIndices, 400, startOctave);
+      await playScale(noteIndices, 400, startOctave, onNotePlay);
       setPlaying(false);
+      onNotePlay?.(null);
     }
   }, [playing, noteIndices]);
 

--- a/transposition-frontend/src/components/play-button/index.tsx
+++ b/transposition-frontend/src/components/play-button/index.tsx
@@ -5,9 +5,11 @@ type PlayButtonProps = {
   /** Chromatic note indices (0=C, 1=C#, ..., 11=B). Single note or scale. */
   noteIndices: number[];
   colour?: 'sky' | 'red' | 'amber' | 'purple';
+  /** Starting octave for playback (default 4 = middle C octave). */
+  startOctave?: number;
 };
 
-function PlayButton({ noteIndices, colour = 'sky' }: PlayButtonProps) {
+function PlayButton({ noteIndices, colour = 'sky', startOctave = 4 }: PlayButtonProps) {
   const [playing, setPlaying] = useState(false);
 
   const colourClasses: Record<string, string> = {
@@ -26,10 +28,10 @@ function PlayButton({ noteIndices, colour = 'sky' }: PlayButtonProps) {
 
     setPlaying(true);
     if (noteIndices.length === 1) {
-      playNote(noteIndices[0]);
+      playNote(noteIndices[0], 500, startOctave);
       setTimeout(() => setPlaying(false), 500);
     } else {
-      await playScale(noteIndices);
+      await playScale(noteIndices, 400, startOctave);
       setPlaying(false);
     }
   }, [playing, noteIndices]);

--- a/transposition-frontend/src/components/staff/index.tsx
+++ b/transposition-frontend/src/components/staff/index.tsx
@@ -14,6 +14,7 @@ type StaffProps = {
   colour?: 'sky' | 'emerald' | 'amber' | 'red' | 'purple';
   noteColour?: 'emerald' | 'red' | 'sky' | 'amber' | 'purple';
   accidentals?: ('sharp' | 'flat' | 'doubleSharp' | 'doubleFlat' | null)[];
+  activeNoteIndex?: number | null;
 };
 
 function Staff({
@@ -24,6 +25,7 @@ function Staff({
   colour,
   noteColour,
   accidentals,
+  activeNoteIndex,
 }: StaffProps) {
   useContext(NotationContext);
 
@@ -50,6 +52,7 @@ function Staff({
           musicalKey={musicalKey}
           noteColour={noteColour}
           accidentals={accidentals}
+          activeNoteIndex={activeNoteIndex}
         />
       </div>
     </div>

--- a/transposition-frontend/src/components/staff/index.tsx
+++ b/transposition-frontend/src/components/staff/index.tsx
@@ -51,6 +51,7 @@ function Staff({
           correspondingNotes={correspondingNotes}
           musicalKey={musicalKey}
           noteColour={noteColour}
+          colour={colour}
           accidentals={accidentals}
           activeNoteIndex={activeNoteIndex}
         />

--- a/transposition-frontend/src/components/staff/staff.css
+++ b/transposition-frontend/src/components/staff/staff.css
@@ -13,6 +13,7 @@
 .staff__text {
   position: absolute;
   top: 0;
+  z-index: 1;
 }
 
 .staff__text__title {

--- a/transposition-frontend/src/components/staff/vexflowStaff.tsx
+++ b/transposition-frontend/src/components/staff/vexflowStaff.tsx
@@ -25,6 +25,7 @@ type VexflowStaffProps = {
   correspondingNotes?: NoteInScale[];
   musicalKey: Key;
   noteColour?: 'emerald' | 'red' | 'sky' | 'amber' | 'purple';
+  colour?: 'sky' | 'emerald' | 'amber' | 'red' | 'purple';
   accidentals?: ('sharp' | 'flat' | 'doubleSharp' | 'doubleFlat' | null)[];
   activeNoteIndex?: number | null;
 };
@@ -34,6 +35,7 @@ function VexflowStaff({
   correspondingNotes,
   musicalKey,
   noteColour,
+  colour,
   accidentals,
   activeNoteIndex,
 }: VexflowStaffProps) {
@@ -180,12 +182,12 @@ function VexflowStaff({
         indicator.style.left = `${pxLeft}px`;
         indicator.style.opacity = '1';
         indicator.style.backgroundColor =
-          noteColour ? (COLOR_MAP[noteColour] ?? '#666') : '#666';
+          colour ? (COLOR_MAP[colour] ?? '#666') : '#666';
       }
     } else if (indicator) {
       indicator.style.opacity = '0';
     }
-  }, [activeNoteIndex, noteColour]);
+  }, [activeNoteIndex, colour]);
 
   return (
     <div ref={containerRef} className="vexflow-staff-container" style={{ position: 'relative' }} />

--- a/transposition-frontend/src/components/staff/vexflowStaff.tsx
+++ b/transposition-frontend/src/components/staff/vexflowStaff.tsx
@@ -178,7 +178,7 @@ function VexflowStaff({
         const svgWidth = viewBox ? parseFloat(viewBox.split(' ')[2]) : 0;
         const containerWidth = svg.getBoundingClientRect().width;
         const scale = containerWidth / svgWidth;
-        const pxLeft = x * scale - 4; // center the 8px dot
+        const pxLeft = x * scale + 4; // center the 8px dot under the note head
         indicator.style.left = `${pxLeft}px`;
         indicator.style.opacity = '1';
         indicator.style.backgroundColor =

--- a/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
@@ -97,6 +97,20 @@ function ScaleTranspositionResults({
   const originConcertPitches = scaleToConcertPitches(originScale.notes, scale, fromKey);
   const transposedConcertPitches = scaleToConcertPitches(transposedScale.notes, targetNote, toKey);
 
+  // Compute the start octave for the transposed scale in interval mode.
+  // When transposing up, if the interval crosses an octave boundary the
+  // transposed scale must start in a higher octave (and vice versa for down).
+  const transposedStartOctave = (() => {
+    if (method === 'key') return 4; // same concert pitch, same octave
+    const originChromatic = enharmonicGroupTransposer(scale);
+    const originAbsolute = originChromatic + 4 * 12;
+    const transposedAbsolute =
+      direction === 'up'
+        ? originAbsolute + interval
+        : originAbsolute - interval;
+    return Math.floor(transposedAbsolute / 12);
+  })();
+
   // --- Staff labels ---
   const originStaffLabel = originInstrumentName
     ? t('stepper.originalInstrumentStaffLabel', {
@@ -258,7 +272,7 @@ function ScaleTranspositionResults({
                   <span className="border-b-4 border-red-300">
                     {transposedStaffLabel}
                   </span>
-                  <PlayButton noteIndices={transposedConcertPitches} colour="red" />
+                  <PlayButton noteIndices={transposedConcertPitches} colour="red" startOctave={transposedStartOctave} />
                 </span>
               }
               colour="red"

--- a/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
@@ -76,6 +76,8 @@ function ScaleTranspositionResults({
   const { selectedNotation } = useContext(NotationContext);
   const { selectedLanguage } = useContext(LanguageContext);
   const [circleExpanded, setCircleExpanded] = useState(method === 'key');
+  const [originActiveNote, setOriginActiveNote] = useState<number | null>(null);
+  const [transposedActiveNote, setTransposedActiveNote] = useState<number | null>(null);
 
   // --- Concert pitches for audio playback ---
   // scaleBuilder.notes wraps values at 12, losing the original SCALES index (0-16).
@@ -257,12 +259,13 @@ function ScaleTranspositionResults({
               displayedNotes={displayedOriginNotes}
               correspondingNotes={originScale.notesInScale}
               musicalKey={originScale.key}
+              activeNoteIndex={originActiveNote}
               text={
                 <span className="flex items-center gap-2">
                   <span className="border-b-4 border-sky-300">
                     {originStaffLabel}
                   </span>
-                  <PlayButton noteIndices={originConcertPitches} colour="sky" />
+                  <PlayButton noteIndices={originConcertPitches} colour="sky" onNotePlay={setOriginActiveNote} />
                 </span>
               }
               colour="sky"
@@ -272,12 +275,13 @@ function ScaleTranspositionResults({
               displayedNotes={displayedTargetNotes}
               correspondingNotes={transposedScale.notesInScale}
               musicalKey={transposedScale.key}
+              activeNoteIndex={transposedActiveNote}
               text={
                 <span className="flex items-center gap-2">
                   <span className="border-b-4 border-red-300">
                     {transposedStaffLabel}
                   </span>
-                  <PlayButton noteIndices={transposedConcertPitches} colour="red" startOctave={transposedStartOctave} />
+                  <PlayButton noteIndices={transposedConcertPitches} colour="red" startOctave={transposedStartOctave} onNotePlay={setTransposedActiveNote} />
                 </span>
               }
               colour="red"

--- a/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
@@ -12,6 +12,7 @@ import Staff from '../../components/staff';
 import CircleOfFifth from '../../components/circle-of-fifth';
 import ContentCard from '../../components/content-card';
 import Button from '../../components/button';
+import PlayButton from '../../components/play-button';
 import NotationContext from '../../contexts/NotationContext';
 import LanguageContext from '../../contexts/LanguageContext';
 
@@ -25,11 +26,13 @@ type ScaleTranspositionResultsProps = {
   direction: 'up' | 'down';
   targetNote: number;
   originScale: {
+    notes: number[];
     notesInScale: NoteInScale[];
     reducedNotes: number[];
     key: Key;
   };
   transposedScale: {
+    notes: number[];
     notesInScale: NoteInScale[];
     reducedNotes: number[];
     key: Key;
@@ -215,8 +218,11 @@ function ScaleTranspositionResults({
               correspondingNotes={originScale.notesInScale}
               musicalKey={originScale.key}
               text={
-                <span className="border-b-4 border-sky-300">
-                  {originStaffLabel}
+                <span className="flex items-center gap-2">
+                  <span className="border-b-4 border-sky-300">
+                    {originStaffLabel}
+                  </span>
+                  <PlayButton noteIndices={originScale.notes} colour="sky" />
                 </span>
               }
               colour="sky"
@@ -227,8 +233,11 @@ function ScaleTranspositionResults({
               correspondingNotes={transposedScale.notesInScale}
               musicalKey={transposedScale.key}
               text={
-                <span className="border-b-4 border-red-300">
-                  {transposedStaffLabel}
+                <span className="flex items-center gap-2">
+                  <span className="border-b-4 border-red-300">
+                    {transposedStaffLabel}
+                  </span>
+                  <PlayButton noteIndices={transposedScale.notes} colour="red" />
                 </span>
               }
               colour="red"

--- a/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
@@ -78,19 +78,24 @@ function ScaleTranspositionResults({
   const [circleExpanded, setCircleExpanded] = useState(method === 'key');
 
   // --- Concert pitches for audio playback ---
-  // scaleBuilder.notes uses SCALES indices (0-16), not chromatic (0-11).
-  // Convert via enharmonicGroupTransposer, then offset by instrument key for concert pitch.
-  function scaleToConcertPitches(scaleNotes: number[], instrumentKey: number): number[] {
-    const firstNote = scaleNotes[0];
-    const chromaticRoot = enharmonicGroupTransposer(firstNote);
+  // scaleBuilder.notes wraps values at 12, losing the original SCALES index (0-16).
+  // Use the scale/targetNote props (true SCALES indices) for the chromatic root,
+  // then derive each note's offset from the raw notes array.
+  function scaleToConcertPitches(
+    scaleNotes: number[],
+    scaleRoot: number,
+    instrumentKey: number
+  ): number[] {
+    const chromaticRoot = enharmonicGroupTransposer(scaleRoot);
+    const firstRawNote = scaleNotes[0];
     return scaleNotes.map(n => {
-      const offset = ((n - firstNote) % 12 + 12) % 12;
+      const offset = ((n - firstRawNote) % 12 + 12) % 12;
       return (chromaticRoot + offset + instrumentKey) % 12;
     });
   }
 
-  const originConcertPitches = scaleToConcertPitches(originScale.notes, fromKey);
-  const transposedConcertPitches = scaleToConcertPitches(transposedScale.notes, toKey);
+  const originConcertPitches = scaleToConcertPitches(originScale.notes, scale, fromKey);
+  const transposedConcertPitches = scaleToConcertPitches(transposedScale.notes, targetNote, toKey);
 
   // --- Staff labels ---
   const originStaffLabel = originInstrumentName

--- a/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/scale-transposition/ScaleTranspositionResults.tsx
@@ -94,8 +94,13 @@ function ScaleTranspositionResults({
     });
   }
 
-  const originConcertPitches = scaleToConcertPitches(originScale.notes, scale, fromKey);
-  const transposedConcertPitches = scaleToConcertPitches(transposedScale.notes, targetNote, toKey);
+  // In key mode, offset by instrument key for concert pitch.
+  // In interval mode, there's no instrument — notes are already concert pitch.
+  const originInstrumentKey = method === 'key' ? fromKey : 0;
+  const targetInstrumentKey = method === 'key' ? toKey : 0;
+
+  const originConcertPitches = scaleToConcertPitches(originScale.notes, scale, originInstrumentKey);
+  const transposedConcertPitches = scaleToConcertPitches(transposedScale.notes, targetNote, targetInstrumentKey);
 
   // Compute the start octave for the transposed scale in interval mode.
   // When transposing up, if the interval crosses an octave boundary the

--- a/transposition-frontend/src/pages/simple-transposition/NoteTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/simple-transposition/NoteTranspositionResults.tsx
@@ -88,6 +88,17 @@ function NoteTranspositionResults({
   const originConcertPitch = method === 'key' ? (note + fromKey) % 12 : note;
   const targetConcertPitch = method === 'key' ? (targetNote + toKey) % 12 : targetNote;
 
+  // In interval mode, compute the target octave when the interval crosses an octave boundary.
+  const targetStartOctave = (() => {
+    if (method === 'key') return 4; // same concert pitch
+    const originAbsolute = note + 4 * 12;
+    const transposedAbsolute =
+      direction === 'up'
+        ? originAbsolute + interval
+        : originAbsolute - interval;
+    return Math.floor(transposedAbsolute / 12);
+  })();
+
   // --- Staff labels ---
   const originStaffLabel = originInstrumentName
     ? t('stepper.originalInstrumentStaffLabel', {
@@ -237,7 +248,7 @@ function NoteTranspositionResults({
                     <span className="border-b-4 border-red-300">
                       {transposedStaffLabel}
                     </span>
-                    <PlayButton noteIndices={[targetConcertPitch]} colour="red" />
+                    <PlayButton noteIndices={[targetConcertPitch]} colour="red" startOctave={targetStartOctave} />
                   </span>
                 }
                 colour="red"

--- a/transposition-frontend/src/pages/simple-transposition/NoteTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/simple-transposition/NoteTranspositionResults.tsx
@@ -81,6 +81,13 @@ function NoteTranspositionResults({
     reversedEnharmonicTargetGroupNotes
   );
 
+  // --- Concert pitch for audio playback ---
+  // In key mode, the written note is not what sounds: a Bb clarinet playing
+  // written C sounds concert Bb. Concert pitch = (writtenNote + instrumentKey) % 12.
+  // In interval mode, notes are already concert pitch (no instrument context).
+  const originConcertPitch = method === 'key' ? (note + fromKey) % 12 : note;
+  const targetConcertPitch = method === 'key' ? (targetNote + toKey) % 12 : targetNote;
+
   // --- Staff labels ---
   const originStaffLabel = originInstrumentName
     ? t('stepper.originalInstrumentStaffLabel', {
@@ -203,7 +210,7 @@ function NoteTranspositionResults({
                   <span className="border-b-4 border-sky-300">
                     {originStaffLabel}
                   </span>
-                  <PlayButton noteIndices={[note]} colour="sky" />
+                  <PlayButton noteIndices={[originConcertPitch]} colour="sky" />
                 </span>
               }
               colour="sky"
@@ -230,7 +237,7 @@ function NoteTranspositionResults({
                     <span className="border-b-4 border-red-300">
                       {transposedStaffLabel}
                     </span>
-                    <PlayButton noteIndices={[targetNote]} colour="red" />
+                    <PlayButton noteIndices={[targetConcertPitch]} colour="red" />
                   </span>
                 }
                 colour="red"

--- a/transposition-frontend/src/pages/simple-transposition/NoteTranspositionResults.tsx
+++ b/transposition-frontend/src/pages/simple-transposition/NoteTranspositionResults.tsx
@@ -9,6 +9,7 @@ import {
 import { getIntervalName } from '../../utils/intervals';
 import { NoteInScale } from '../../utils/scaleBuilder';
 import Staff from '../../components/staff';
+import PlayButton from '../../components/play-button';
 import ContentCard from '../../components/content-card';
 import NotationContext from '../../contexts/NotationContext';
 import LanguageContext from '../../contexts/LanguageContext';
@@ -198,8 +199,11 @@ function NoteTranspositionResults({
                   : undefined
               }
               text={
-                <span className="border-b-4 border-sky-300">
-                  {originStaffLabel}
+                <span className="flex items-center gap-2">
+                  <span className="border-b-4 border-sky-300">
+                    {originStaffLabel}
+                  </span>
+                  <PlayButton noteIndices={[note]} colour="sky" />
                 </span>
               }
               colour="sky"
@@ -222,8 +226,11 @@ function NoteTranspositionResults({
                     : undefined
                 }
                 text={
-                  <span className="border-b-4 border-red-300">
-                    {transposedStaffLabel}
+                  <span className="flex items-center gap-2">
+                    <span className="border-b-4 border-red-300">
+                      {transposedStaffLabel}
+                    </span>
+                    <PlayButton noteIndices={[targetNote]} colour="red" />
                   </span>
                 }
                 colour="red"

--- a/transposition-frontend/src/utils/audioPlayer.test.ts
+++ b/transposition-frontend/src/utils/audioPlayer.test.ts
@@ -17,4 +17,12 @@ describe('noteIndexToFrequency', () => {
   it('returns 277.18 for C#/Db (index 1)', () => {
     expect(noteIndexToFrequency(1)).toBeCloseTo(277.18, 1);
   });
+
+  it('returns 523.25 for C in octave 5', () => {
+    expect(noteIndexToFrequency(0, 5)).toBeCloseTo(523.25, 1);
+  });
+
+  it('returns 130.81 for C in octave 3', () => {
+    expect(noteIndexToFrequency(0, 3)).toBeCloseTo(130.81, 1);
+  });
 });

--- a/transposition-frontend/src/utils/audioPlayer.test.ts
+++ b/transposition-frontend/src/utils/audioPlayer.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { noteIndexToFrequency } from './audioPlayer';
+
+describe('noteIndexToFrequency', () => {
+  it('returns 261.63 for C (index 0)', () => {
+    expect(noteIndexToFrequency(0)).toBeCloseTo(261.63, 1);
+  });
+
+  it('returns 440 for A (index 9)', () => {
+    expect(noteIndexToFrequency(9)).toBeCloseTo(440, 1);
+  });
+
+  it('returns 493.88 for B (index 11)', () => {
+    expect(noteIndexToFrequency(11)).toBeCloseTo(493.88, 1);
+  });
+
+  it('returns 277.18 for C#/Db (index 1)', () => {
+    expect(noteIndexToFrequency(1)).toBeCloseTo(277.18, 1);
+  });
+});

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -1,0 +1,89 @@
+let audioContext: AudioContext | null = null;
+let currentAbortController: AbortController | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  if (audioContext.state === 'suspended') {
+    audioContext.resume();
+  }
+  return audioContext;
+}
+
+/**
+ * Convert a chromatic note index (0=C, 1=C#, ..., 9=A, 11=B)
+ * to frequency in Hz using equal temperament. Octave 4 (middle C = C4).
+ */
+export function noteIndexToFrequency(noteIndex: number): number {
+  return 440 * Math.pow(2, (noteIndex - 9) / 12);
+}
+
+/**
+ * Play a single note as a sine wave.
+ */
+export function playNote(noteIndex: number, durationMs = 500): void {
+  const ctx = getAudioContext();
+  const oscillator = ctx.createOscillator();
+  const gainNode = ctx.createGain();
+
+  oscillator.type = 'sine';
+  oscillator.frequency.value = noteIndexToFrequency(noteIndex);
+
+  gainNode.gain.setValueAtTime(0.3, ctx.currentTime);
+  const fadeStart = ctx.currentTime + durationMs / 1000 - 0.05;
+  gainNode.gain.setValueAtTime(0.3, fadeStart);
+  gainNode.gain.linearRampToValueAtTime(0, fadeStart + 0.05);
+
+  oscillator.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  oscillator.start();
+  oscillator.stop(ctx.currentTime + durationMs / 1000);
+}
+
+/**
+ * Play a sequence of notes (for scales). Returns a promise that resolves when done.
+ * Call stopPlayback() to cancel.
+ */
+export async function playScale(
+  noteIndices: number[],
+  tempoMs = 400
+): Promise<void> {
+  stopPlayback();
+  const controller = new AbortController();
+  currentAbortController = controller;
+
+  for (let i = 0; i < noteIndices.length; i++) {
+    if (controller.signal.aborted) return;
+    playNote(noteIndices[i], tempoMs - 50);
+    if (i < noteIndices.length - 1) {
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(resolve, tempoMs);
+        controller.signal.addEventListener('abort', () => {
+          clearTimeout(timeout);
+          reject(new DOMException('Aborted', 'AbortError'));
+        }, { once: true });
+      }).catch(() => {});
+      if (controller.signal.aborted) return;
+    }
+  }
+  currentAbortController = null;
+}
+
+/**
+ * Stop any in-progress scale playback.
+ */
+export function stopPlayback(): void {
+  if (currentAbortController) {
+    currentAbortController.abort();
+    currentAbortController = null;
+  }
+}
+
+/**
+ * Check if audio is currently playing.
+ */
+export function isPlaying(): boolean {
+  return currentAbortController !== null;
+}

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -103,8 +103,8 @@ export function stopPlayback(): void {
     try {
       gain.gain.cancelScheduledValues(now);
       gain.gain.setValueAtTime(gain.gain.value, now);
-      gain.gain.linearRampToValueAtTime(0, now + 0.02);
-      oscillator.stop(now + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.05);
+      oscillator.stop(now + 0.05);
     } catch { /* already stopped */ }
   }
   activeNodes = [];

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -96,12 +96,15 @@ export function stopPlayback(): void {
     currentAbortController.abort();
     currentAbortController = null;
   }
-  // Silence any active oscillators immediately
+  // Fade out active oscillators quickly to avoid click/pop
+  const ctx = audioContext;
+  const now = ctx ? ctx.currentTime : 0;
   for (const { oscillator, gain } of activeNodes) {
     try {
-      gain.gain.cancelScheduledValues(0);
-      gain.gain.setValueAtTime(0, 0);
-      oscillator.stop();
+      gain.gain.cancelScheduledValues(now);
+      gain.gain.setValueAtTime(gain.gain.value, now);
+      gain.gain.linearRampToValueAtTime(0, now + 0.02);
+      oscillator.stop(now + 0.02);
     } catch { /* already stopped */ }
   }
   activeNodes = [];

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -69,16 +69,14 @@ export async function playScale(
 
     onNotePlay?.(i);
     playNote(noteIndices[i], tempoMs - 50, currentOctave);
-    if (i < noteIndices.length - 1) {
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(resolve, tempoMs);
-        controller.signal.addEventListener('abort', () => {
-          clearTimeout(timeout);
-          reject(new DOMException('Aborted', 'AbortError'));
-        }, { once: true });
-      }).catch(() => {});
-      if (controller.signal.aborted) return;
-    }
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(resolve, tempoMs);
+      controller.signal.addEventListener('abort', () => {
+        clearTimeout(timeout);
+        reject(new DOMException('Aborted', 'AbortError'));
+      }, { once: true });
+    }).catch(() => {});
+    if (controller.signal.aborted) return;
   }
   currentAbortController = null;
 }

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -13,22 +13,23 @@ function getAudioContext(): AudioContext {
 
 /**
  * Convert a chromatic note index (0=C, 1=C#, ..., 9=A, 11=B)
- * to frequency in Hz using equal temperament. Octave 4 (middle C = C4).
+ * to frequency in Hz using equal temperament.
+ * Default octave 4 (middle C = C4).
  */
-export function noteIndexToFrequency(noteIndex: number): number {
-  return 440 * Math.pow(2, (noteIndex - 9) / 12);
+export function noteIndexToFrequency(noteIndex: number, octave = 4): number {
+  return 440 * Math.pow(2, (noteIndex - 9) / 12 + (octave - 4));
 }
 
 /**
  * Play a single note as a sine wave.
  */
-export function playNote(noteIndex: number, durationMs = 500): void {
+export function playNote(noteIndex: number, durationMs = 500, octave = 4): void {
   const ctx = getAudioContext();
   const oscillator = ctx.createOscillator();
   const gainNode = ctx.createGain();
 
   oscillator.type = 'sine';
-  oscillator.frequency.value = noteIndexToFrequency(noteIndex);
+  oscillator.frequency.value = noteIndexToFrequency(noteIndex, octave);
 
   gainNode.gain.setValueAtTime(0.3, ctx.currentTime);
   const fadeStart = ctx.currentTime + durationMs / 1000 - 0.05;
@@ -54,9 +55,17 @@ export async function playScale(
   const controller = new AbortController();
   currentAbortController = controller;
 
+  let currentOctave = 4;
+
   for (let i = 0; i < noteIndices.length; i++) {
     if (controller.signal.aborted) return;
-    playNote(noteIndices[i], tempoMs - 50);
+
+    // When the next note is lower than the previous, we've wrapped around the octave
+    if (i > 0 && noteIndices[i] < noteIndices[i - 1]) {
+      currentOctave++;
+    }
+
+    playNote(noteIndices[i], tempoMs - 50, currentOctave);
     if (i < noteIndices.length - 1) {
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(resolve, tempoMs);

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -49,13 +49,14 @@ export function playNote(noteIndex: number, durationMs = 500, octave = 4): void 
  */
 export async function playScale(
   noteIndices: number[],
-  tempoMs = 400
+  tempoMs = 400,
+  startOctave = 4
 ): Promise<void> {
   stopPlayback();
   const controller = new AbortController();
   currentAbortController = controller;
 
-  let currentOctave = 4;
+  let currentOctave = startOctave;
 
   for (let i = 0; i < noteIndices.length; i++) {
     if (controller.signal.aborted) return;

--- a/transposition-frontend/src/utils/audioPlayer.ts
+++ b/transposition-frontend/src/utils/audioPlayer.ts
@@ -50,7 +50,8 @@ export function playNote(noteIndex: number, durationMs = 500, octave = 4): void 
 export async function playScale(
   noteIndices: number[],
   tempoMs = 400,
-  startOctave = 4
+  startOctave = 4,
+  onNotePlay?: (index: number) => void
 ): Promise<void> {
   stopPlayback();
   const controller = new AbortController();
@@ -66,6 +67,7 @@ export async function playScale(
       currentOctave++;
     }
 
+    onNotePlay?.(i);
     playNote(noteIndices[i], tempoMs - 50, currentOctave);
     if (i < noteIndices.length - 1) {
       await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- **Audio playback** via Web Audio API (pure sine wave synthesis, zero dependencies) for both note and scale transposition results
- **Concert pitch correctness**: cross-instrument mode plays the same concert pitch for both staves; interval mode applies proper octave offsets
- **Visual feedback** during scale playback: subtle opacity dimming on inactive notes + colored indicator dot tracking the active note on the staff

## Test plan
- [ ] Play a single note in note transposition — correct pitch, play/stop toggle works
- [ ] Play a scale — notes ascend correctly across octave boundaries
- [ ] Cross-instrument mode (e.g. Bb clarinet): both staves produce the same concert pitch
- [ ] Interval mode (e.g. octave up): transposed scale starts in the correct higher octave
- [ ] Visual feedback: indicator dot follows each note, stays visible for the last note, uses instrument colour
- [ ] Stop mid-playback: dot disappears, opacity resets
- [ ] Responsive: dot position stays centered when window is resized

🤖 Generated with [Claude Code](https://claude.com/claude-code)